### PR TITLE
This is the implementation idea for exposing our query endpoint

### DIFF
--- a/distribution/all/groups.js
+++ b/distribution/all/groups.js
@@ -1,4 +1,4 @@
-const distribution = global.distribution;
+let distribution = global.distribution;
 
 function DistributedGroupsService(groupInfo) {
   this.context = {};
@@ -35,6 +35,7 @@ DistributedGroupsService.prototype.get = function(gid, cb) {
  * @param {Function} cb
  */
 DistributedGroupsService.prototype.put = function(group, nodes, cb) {
+  distribution = global.distribution;
   distribution.local.groups.put(group, nodes, (err, val) => {
     const remote = {service: 'groups', method: 'put'};
     distribution[this.context.gid].comm.send([group, nodes], remote, (e, v) => {

--- a/distribution/local/local.js
+++ b/distribution/local/local.js
@@ -45,6 +45,7 @@ const mem = require('./mem');
 // persistent
 const store = require('./store');
 
+const query = require('./query');
 
 /* Routes Service */
 
@@ -56,6 +57,7 @@ routes.put(rpc, 'rpc', () => {});
 routes.put(gossip, 'gossip', () => {});
 routes.put(mem, 'mem', () => {});
 routes.put(store, 'store', () => {});
+routes.put(query, 'query', () => {});
 
 module.exports = {
   status: status,

--- a/distribution/local/node.js
+++ b/distribution/local/node.js
@@ -2,7 +2,7 @@ const http = require('http');
 const {routes} = require('./local');
 const util = require('../util/util');
 const node = global.nodeConfig;
-
+const groupsTemplate = require('../all/groups');
 const start = function(started) {
   const server = http.createServer((req, res) => {
     // Callback function to send back response
@@ -49,13 +49,30 @@ const start = function(started) {
       });
     });
   });
+  const crawlerSetup = function (cb) {
 
+    // WE NEED TO CHANGE THIS TO MATCH FOR AWS INSTANCES. WE ALSO HAVE TO DEPLOY THIS NODE LAST OR HAVE THIS NODE SPAWN THE OTHERS
+    if (node.port === 8080) {
+      const crwalerGroup = {};
+      const n1 = {ip: '127.0.0.1', port: 7110};
+      const n2 = {ip: '127.0.0.1', port: 7111};
+      const n3 = {ip: '127.0.0.1', port: 7112};
+      crwalerGroup[global.distribution.util.id.getSID(n1)] = n1;
+      crwalerGroup[global.distribution.util.id.getSID(n2)] = n2;
+      crwalerGroup[global.distribution.util.id.getSID(n3)] = n3;
+      groupsTemplate({gid: 'crawler'}).put({gid: 'crawler'}, crwalerGroup, (e, v) => {
+        cb();
+      });
+    }
+    else {
+      cb()
+    }
+  }
   server.listen(node.port, node.ip, () => {
     global.nodeServer = server;
-    if (node.port === 8000) {
-      // console.log('node:', started.toString());
-    }
-    started(server);
+    crawlerSetup(()=> {
+      started(server);
+    })
   });
 };
 

--- a/distribution/local/query.js
+++ b/distribution/local/query.js
@@ -1,0 +1,34 @@
+const queryWorkflow = require('../workflow/query');
+function QueryService() {
+    // {serviceName: serviceObj}
+    this.hashed = {
+    };
+}
+
+function defaultCallback(error, value) {
+    if (error) {
+        console.log(error);
+    } else {
+        console.log(value);
+    }
+}
+
+QueryService.prototype.get = function(queryInput, cb=defaultCallback) {
+    // global.distribution["crawler"].mem.put(key, (e, v) => {
+    // global.distribution["crawler"].store.get(null, (e, v)=> {
+    //     const filteredArray = array.filter(element => element.startsWith("index-"));
+    //     queryConfig = {
+    //         gid : 'crawler',
+    //         keys : filtered_list,
+    //     }
+    //     queryService = queryWorkflow(queryConfig);
+    //     global.distribution["crawler"].mr.exec(queryService, (e, v) => {
+    //         cb(e, v);
+    //     })
+    //     });
+    //     });
+    cb(null, "Further implementation required");
+    }
+
+    const query = new QueryService();
+module.exports = query;


### PR DESCRIPTION
group.js: I had to make it let cuz distribution object was not available yet. But it will be available when the function is called.
Node.js: We have a startup function already. During the startup phase, we have to put the crawler group. We also have additional work to do. Like running the actual crawler and running the indexer.

Query.js: The new endpoint that will be exposed. We can call this endpoint like awsIP:awsPORT/query/get with the query passed as an object. This will execute the query subsystem.

ADDITIONAL WORK:
1. We have to think about how we will spawn the rest of the nodes.
2. We also have to define serialization and deserializion libraries in the frontend.
3. We have to run the crawler and indexer workflow during startup.
4. We can also have a hashmap to return the values since our function is idempotent.

LET ME KNOW IF THIS SEEMS LIKE A GOOD IMPLEMENTATION OR IF ANYTHING NEEDS TO BE CHANGED